### PR TITLE
Fixed issue with non-components using "component" flag in json

### DIFF
--- a/src/ComponentInstaller/Process/Process.php
+++ b/src/ComponentInstaller/Process/Process.php
@@ -62,14 +62,24 @@ class Process implements ProcessInterface
         }
 
         // Get the available packages.
+        $allPackages = array();
         $locker = $this->composer->getLocker();
         if (isset($locker)) {
             $lockData = $locker->getLockData();
-            $this->packages = isset($lockData['packages']) ? $lockData['packages'] : array();
+            $allPackages = isset($lockData['packages']) ? $lockData['packages'] : array();
 
             // Also merge in any of the development packages.
             $dev = isset($lockData['packages-dev']) ? $lockData['packages-dev'] : array();
             foreach ($dev as $package) {
+                $allPackages[] = $package;
+            }
+        }
+
+        // Only add those packages that we can reasonably 
+        // assume are components into our packages list
+        foreach ($allPackages as $package) {
+            $extra = isset($package['extra']) ? $package['extra'] : array();
+            if (isset($extra['component']) && is_array($extra['component'])) {
                 $this->packages[] = $package;
             }
         }


### PR DESCRIPTION
Hi, there!

I'm not sure if this was successfully set to you yesterday. It's a simple fix for a problem I ran into.

-joel

When non-component files use a "component" flag (see cartalyst/sentry as an example),
the component-installer script would start throwing errors like this:

> Script ComponentInstaller\Installer::postAutoloadDump handling the post-autoload-dump event terminated with an exception
> 
> [ErrorException]
> Argument 2 passed to ComponentInstaller\Process\RequireJsProcess::aggregateScripts() must be an array, string given, called in <project>/vendor/robloach/component-installer/src/ComponentInstaller/Process/RequireJsProcess.php on line 109 and defined

This fix removes everything it can identify as a non-component from the list of packages.
