### PR TITLE
Install Components in the vendor directory

### DIFF
--- a/src/ComponentInstaller/Installer.php
+++ b/src/ComponentInstaller/Installer.php
@@ -56,11 +56,12 @@ class Installer extends LibraryInstaller
     }
 
     /**
-     * {@inheritDoc}
+     * Gets the destination Component directory.
      *
-     * Components are to be installed directly into the "component-dir".
+     * @return string
+     *   The path to where the final Component should be installed.
      */
-    public function getInstallPath(PackageInterface $package)
+    public function getComponentPath(PackageInterface $package)
     {
         // Parse the pretty name for the vendor and package name.
         $name = $prettyName = $package->getPrettyName();
@@ -112,7 +113,7 @@ class Installer extends LibraryInstaller
      */
     public function removeComponent(PackageInterface $package)
     {
-        $path = $this->getInstallPath($package);
+        $path = $this->getComponentPath($package);
         return $this->filesystem->remove($path);
     }
 

--- a/src/ComponentInstaller/Process/CopyProcess.php
+++ b/src/ComponentInstaller/Process/CopyProcess.php
@@ -36,15 +36,11 @@ class CopyProcess extends Process
      */
     public function copy($packages)
     {
+        // Iterate over each package that should be processed.
         foreach ($packages as $package) {
-            // Skip processing the package if it's a "component", because then
-            // it is already available in the component directory. Root packages
-            // are still to be processed, whether or not they're "components".
+            // Retrieve some basic information about the package.
             $type = isset($package['type']) ? $package['type'] : 'library';
             $root = isset($package['is-root']) ? $package['is-root'] : false;
-            if ($type == 'component' && !$root) {
-                continue;
-            }
 
             // Retrieve some information about the package.
             $packageDir = $this->getVendorDir($package);

--- a/tests/ComponentInstaller/Test/InstallerTest.php
+++ b/tests/ComponentInstaller/Test/InstallerTest.php
@@ -99,33 +99,33 @@ class InstallerTest extends LibraryInstallerTest
     }
 
     /**
-     * Tests the Installer's getInstallPath function.
+     * Tests the Installer's getComponentPath function.
      *
      * @param $expected
      *   The expected install path for the package.
      * @param $package
      *   The package to test upon.
      *
-     * @dataProvider providerComponentGetInstallPath
+     * @dataProvider providerGetComponentPath
      *
-     * @see \ComponentInstaller\Installer::getInstallPath()
+     * @see \ComponentInstaller\Installer::getComponentPath()
      */
-    public function testComponentGetInstallPath($expected, $package) {
+    public function testGetComponentPath($expected, $package) {
         // Construct the mock objects.
         $installer = new Installer($this->io, $this->composer, 'component');
         $loader = new ArrayLoader();
 
         // Test the results.
-        $result = $installer->getInstallPath($loader->load($package));
+        $result = $installer->getComponentPath($loader->load($package));
         $this->assertEquals($this->componentDir . '/' . $expected, $result);
     }
 
     /**
-     * Data provider for testComponentGetInstallPath().
+     * Data provider for testGetComponentPath().
      *
-     * @see testGetInstallPath()
+     * @see testGetComponentPath()
      */
-    public function providerComponentGetInstallPath()
+    public function providerGetComponentPath()
     {
         $package = array(
             'name' => 'foo/bar',


### PR DESCRIPTION
This installed Components into the `vendor-dir`, and then copies the individual files to the `components-dir`. Fixes #40.
