### PR TITLE
Strengthening checks around Locker use.

### DIFF
--- a/src/ComponentInstaller/Process/Process.php
+++ b/src/ComponentInstaller/Process/Process.php
@@ -89,9 +89,9 @@ class Process implements ProcessInterface
         $allPackages = array();
         /** @var \Composer\Package\Locker $locker */
         $locker = $this->composer->getLocker();
-        if (isset($locker)) {
+        if ($locker !== null && $locker->isLocked()) {
             $lockData = $locker->getLockData();
-            $allPackages = isset($lockData['packages']) ? $lockData['packages'] : array();
+            $allPackages = $lockData['packages'];
 
             // Also merge in any of the development packages.
             $dev = isset($lockData['packages-dev']) ? $lockData['packages-dev'] : array();


### PR DESCRIPTION
Hi Rob,

I just changed the way you check if the locker is available or not in the "init()" method.
At this point in the process, since we are in post-dump-autoload, we should be safe to assume that the lockfile is created. Therefore, the test as you wrote (`if (isset(($locker)) {...}`) should always be true.

However, in very special circumstances (like when you are using [EmbeddedComposer](https://github.com/dflydev/dflydev-embedded-composer), there can be really no lock file. The test is still true, but the call to `$locker->getLockData()` throws an exception (lock file not found). The piece of code I added actually checks that the lock file exists, and the test fails if the lock file does not exist (or if it contains no packages).