### PR TITLE
Fix supports() to only support "component" types

### DIFF
--- a/src/ComponentInstaller/Installer.php
+++ b/src/ComponentInstaller/Installer.php
@@ -55,8 +55,8 @@ class Installer extends LibraryInstaller
             }
         }
 
-        // Explicitly state support of "component" packages.
-        return true;
+        // State support for "component" package types.
+        return $packageType == 'component';
     }
 
     /**

--- a/tests/ComponentInstaller/Test/InstallerTest.php
+++ b/tests/ComponentInstaller/Test/InstallerTest.php
@@ -101,7 +101,7 @@ class InstallerTest extends LibraryInstallerTest
     {
         // All package types support having Components.
         $tests[] = array('component', true);
-        $tests[] = array('all-supported', true);
+        $tests[] = array('all-supported', false);
 
         return $tests;
     }


### PR DESCRIPTION
RE: https://github.com/composer/installers/issues/243 https://github.com/RobLoach/component-installer/issues/86

cc @slbmeh