### PR TITLE
Open up Process loading and added configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 vendor
 .idea
+nbproject
 .project
 composer.phar
 composer.lock

--- a/src/ComponentInstaller/Process/Process.php
+++ b/src/ComponentInstaller/Process/Process.php
@@ -76,10 +76,10 @@ class Process implements ProcessInterface
         $this->io = isset($io) ? $io : new NullIO();
         $this->fs = new Filesystem();
         $this->installationManager = $this->composer->getInstallationManager();
-
+        
         // TODO: Break compatibility and expect in interface
-        $options = func_get_arg(2);
-        $this->options = is_array($options) ? $options : null;
+        $args = func_get_args();
+        $this->options = count($args) > 2 && is_array($args[2]) ? $args[2]: array();
     }
 
     /**

--- a/src/ComponentInstaller/Process/Process.php
+++ b/src/ComponentInstaller/Process/Process.php
@@ -62,6 +62,12 @@ class Process implements ProcessInterface
     protected $installationManager;
 
     /**
+     * Any user provided options to configure this process.
+     * @var array
+     */
+    protected $options;
+
+    /**
      * {@inheritdoc}
      */
     public function __construct(Composer $composer = null, IOInterface $io = null)
@@ -70,6 +76,10 @@ class Process implements ProcessInterface
         $this->io = isset($io) ? $io : new NullIO();
         $this->fs = new Filesystem();
         $this->installationManager = $this->composer->getInstallationManager();
+
+        // TODO: Break compatibility and expect in interface
+        $options = func_get_arg(2);
+        $this->options = is_array($options) ? $options : null;
     }
 
     /**


### PR DESCRIPTION
Processes used to be immutable and without an additional fork Users
could not modify or create their own processes. This commit allows
to define any Process currently available to be used and configure
Process behavior by using the options of said Process.

This change is fully backwards compatible. No contract is changed.
Right now no additional configuration has been added.

Signed-off-by: Thomas Vogt <thomas.vogt@tuta.io>